### PR TITLE
More variables (plus a couple of enhancements)

### DIFF
--- a/minecraft/lunatrius/ingameinfo/InGameInfoCore.java
+++ b/minecraft/lunatrius/ingameinfo/InGameInfoCore.java
@@ -663,34 +663,28 @@ public class InGameInfoCore {
 				return Boolean.toString(this.world.getWorldInfo().isHardcoreModeEnabled());
 			} else if (var.equalsIgnoreCase("underwater")) {
 				return Boolean.toString(this.player.isInsideOfMaterial(Material.water));
-			} else if (var.equalsIgnoreCase("equippedname")) {
-				ItemStack item = this.player.getCurrentEquippedItem();
-				String arrows = item != null && item.itemID == Item.bow.shiftedIndex ? " (" + getArrowsInInventory(this.player) + ")" : "";
-				return item != null ? item.getDisplayName() + arrows : "";
-			} else if (var.equalsIgnoreCase("equippeddamage")) {
-				ItemStack item = this.player.getCurrentEquippedItem();
-				return Integer.toString(item != null && item.isItemStackDamageable() ? item.getItemDamage() : 0);
-			} else if (var.equalsIgnoreCase("equippeddamageleft")) {
-				ItemStack item = this.player.getCurrentEquippedItem();
-				return Integer.toString(item != null && item.isItemStackDamageable() ? item.getMaxDamage() + 1 - item.getItemDamage() : 0);
-			} else if (var.equalsIgnoreCase("equippedmaxdamage")) {
-				ItemStack item = this.player.getCurrentEquippedItem();
-				return Integer.toString(item != null && item.isItemStackDamageable() ? item.getMaxDamage() + 1 : 0);
-			} else if (var.matches("(helmet|chestplate|leggings|boots)(name|maxdamage|damage|damageleft)")) {
-				int slot = -1;
-				if (var.startsWith("helmet")) {
-					slot = 3;
-				} else if (var.startsWith("chestplate")) {
-					slot = 2;
-				} else if (var.startsWith("leggings")) {
-					slot = 1;
-				} else if (var.startsWith("boots")) {
-					slot = 0;
+			} else if (var.matches("(equipped|helmet|chestplate|leggings|boots)(name|maxdamage|damage|damageleft)")) {
+				ItemStack item;
+
+				if (var.startsWith("equipped")) {
+					item = this.player.getCurrentEquippedItem();
+				} else {
+					int slot = -1;
+					if (var.startsWith("helmet")) {
+						slot = 3;
+					} else if (var.startsWith("chestplate")) {
+						slot = 2;
+					} else if (var.startsWith("leggings")) {
+						slot = 1;
+					} else if (var.startsWith("boots")) {
+						slot = 0;
+					}
+					item = this.player.inventory.armorItemInSlot(slot);
 				}
 
-				ItemStack item = this.player.inventory.armorItemInSlot(slot);
 				if (var.endsWith("name")) {
-					return item != null ? item.getDisplayName() : "";
+					String arrows = item != null && item.itemID == Item.bow.shiftedIndex ? " (" + getArrowsInInventory(this.player) + ")" : "";
+					return item != null ? item.getDisplayName() + arrows : "";
 				} else if (var.endsWith("maxdamage")) {
 					return Integer.toString(item != null && item.isItemStackDamageable() ? item.getMaxDamage() + 1 : 0);
 				} else if (var.endsWith("damage")) {


### PR DESCRIPTION
This patch adds half a dozen new variables related to the player HUD:
- **healthpoints** — the player's current health, in half-hearts
- **armorpoints** — the player's current total armor, in half-… er, armors (icons)
- **foodpoints** — the player's current food level, in half-shanks
- **foodsaturation** — the player's current saturation level, an otherwise invisible value
- **airticks** — the player's remaining air supply, in game ticks
- **underwater** — `true` if the player's head is in liquid (i.e. if they're holding their breath), otherwise `false`

A few "enum-style" variables (`difficulty`, `gamemode`, and `dimension`) have been changed to use names supplied by the game.  This allows localized difficulty and gamemode names as well as the names of mod dimensions.  Additionally, `*id` variants have been added for those three, plus `biome`, which return the variable as a number, so that logic can be performed using them.

Finally, the `equipped*` variables have been folded into the armor block, as the handling was virtually identical.
